### PR TITLE
VMNetworkAdapter: add parameter IgnoreNetworkSetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
     all unit tests.
 - xVhdFileDirectory
   - Added initial set of unit tests
+- xVMNetworkAdapter
+  - add parameter IgnoreNetworkSetting
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -377,6 +377,9 @@ Manages VMNetadapters attached to a Hyper-V virtual machine or the management OS
 * **`[String]` VMName** _(Required)_: Name of the VM to attach to.
   If you want to attach new VM Network adapter to the management OS,
   set this property to 'Management OS'.
+* **`[Boolean]` IgnoreNetworkSetting** _(Write)_:  If specified with `True` the network settings of the network adapter are not changed.
+  This should be set if the guest operating system configures the network adapter.
+  Default value is `False`.
 * **`[NetworkSettings]` NetworkSetting** _(Write)_: Network Settings of the network adapter.
   If this parameter is not supplied, DHCP will be used.
 * **`[String]` MacAddress** _(Write)_: Use this to specify a Static MAC Address.

--- a/source/DSCResources/DSC_VMNetworkAdapter/DSC_VMNetworkAdapter.psm1
+++ b/source/DSCResources/DSC_VMNetworkAdapter/DSC_VMNetworkAdapter.psm1
@@ -473,7 +473,7 @@ function Test-TargetResource
                     }
                 }
 
-                if( $IgnoreNetworkSetting -ne $true )
+                if ($IgnoreNetworkSetting -ne $true)
                 {
                     $networkInfo = Get-NetworkInformation -VMName $VMName -Name $Name
                     if (-not $NetworkSetting)

--- a/source/DSCResources/DSC_VMNetworkAdapter/DSC_VMNetworkAdapter.schema.mof
+++ b/source/DSCResources/DSC_VMNetworkAdapter/DSC_VMNetworkAdapter.schema.mof
@@ -16,6 +16,7 @@ class DSC_VMNetworkAdapter : OMI_BaseResource
     [Required] String SwitchName;
     [Required] String VMName;
     [Write] String MacAddress;
+    [Write] Boolean IgnoreNetworkSetting;
     [Write, EmbeddedInstance("NetworkSettings")] String NetworkSetting;
     [Write] String VlanId;
     [Write, ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;


### PR DESCRIPTION
#### Pull Request (PR) description

xVMNetworkAdapter: add parameter IgnoreNetworkSetting

Set the new parameter to `True` if the guest operating system configures the network adapter.
In this case all ip settings including DHCP are skipped.
The paramter is set to `False` as default to keep the current behavior.


#### This Pull Request (PR) fixes the following issues


#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/hypervdsc/189)
<!-- Reviewable:end -->
