### PR TITLE
VMHardDiskDrive: Return Absent when VM does not exist instead of throwing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+- VMHardDiskDrive
+  - `Get-TargetResource` no longer throws when the VM does not exist. Returns
+    `Ensure = 'Absent'` so `Test-TargetResource` correctly reports the resource
+    is not in desired state instead of aborting the configuration - Fixes
+    [Issue #223](https://github.com/dsccommunity/HyperVDsc/issues/223).
 - HyperVDsc
   - BREAKING CHANGE
     - Renamed _xHyper-V_ to _HyperVDsc - fixes [Issue #69](https://github.com/dsccommunity/HyperVDsc/issues/213).

--- a/source/DSCResources/DSC_VMHardDiskDrive/DSC_VMHardDiskDrive.psm1
+++ b/source/DSCResources/DSC_VMHardDiskDrive/DSC_VMHardDiskDrive.psm1
@@ -38,7 +38,7 @@ function Get-TargetResource
     $vm = Get-VM -Name $VMName -ErrorAction SilentlyContinue
     if ($null -eq $vm)
     {
-        Write-Verbose -Message ($script:localizedData.DiskNotFound -f $Path, $VMName)
+        Write-Verbose -Message ($script:localizedData.VMNotFound -f $VMName)
         return @{
             VMName             = $VMName
             Path               = $null

--- a/source/DSCResources/DSC_VMHardDiskDrive/DSC_VMHardDiskDrive.psm1
+++ b/source/DSCResources/DSC_VMHardDiskDrive/DSC_VMHardDiskDrive.psm1
@@ -31,6 +31,24 @@ function Get-TargetResource
 
     Assert-Module -ModuleName 'Hyper-V'
 
+    # Check if the VM exists before querying its hard disk drives.
+    # When the VM has not been created yet (e.g., during initial provisioning
+    # with dependsOn), return Absent rather than throwing so that
+    # Test-TargetResource can report the resource is not in desired state.
+    $vm = Get-VM -Name $VMName -ErrorAction SilentlyContinue
+    if ($null -eq $vm)
+    {
+        Write-Verbose -Message ($script:localizedData.DiskNotFound -f $Path, $VMName)
+        return @{
+            VMName             = $VMName
+            Path               = $null
+            ControllerType     = $null
+            ControllerNumber   = $null
+            ControllerLocation = $null
+            Ensure             = 'Absent'
+        }
+    }
+
     $hardDiskDrive = Get-VMHardDiskDrive -VMName $VMName -ErrorAction Stop |
         Where-Object -FilterScript { $_.Path -eq $Path }
 

--- a/source/DSCResources/DSC_VMHardDiskDrive/en-US/DSC_VMHardDiskDrive.strings.psd1
+++ b/source/DSCResources/DSC_VMHardDiskDrive/en-US/DSC_VMHardDiskDrive.strings.psd1
@@ -1,6 +1,7 @@
 ConvertFrom-StringData @'
     DiskFound                    = Found hard disk '{0}' attached to VM '{1}'.
     DiskNotFound                 = Hard disk '{0}' missing from VM '{1}'
+    VMNotFound                   = VM '{0}' not found.
     CheckingDiskIsAttached       = Checking if the disk is already attached to the VM.
     CheckingExistingDiskLocation = Checking if there is an existing disk in the specified location.
     AddingDisk                   = Adding the disk '{0}' to VM '{1}'.

--- a/tests/Unit/DSC_VMHardDiskDrive.Tests.ps1
+++ b/tests/Unit/DSC_VMHardDiskDrive.Tests.ps1
@@ -50,6 +50,7 @@ try
             Mock -CommandName Assert-Module
 
             It 'Should return a [System.Collections.Hashtable] object type' {
+                Mock -CommandName Get-VM { return [PSCustomObject]@{ Name = $testVMName } }
                 Mock -CommandName Get-VMHardDiskDrive { return $stubHardDiskDrive }
 
                 $result = Get-TargetResource -VMName $testVMName -Path $testhardDiskPath
@@ -58,6 +59,7 @@ try
             }
 
             It 'Should return "Present" when hard disk is attached' {
+                Mock -CommandName Get-VM { return [PSCustomObject]@{ Name = $testVMName } }
                 Mock -CommandName Get-VMHardDiskDrive { return $stubHardDiskDrive }
 
                 $result = Get-TargetResource -VMName $testVMName -Path $testhardDiskPath
@@ -66,6 +68,7 @@ try
             }
 
             It 'Should return "Absent" when hard disk is not attached' {
+                Mock -CommandName Get-VM { return [PSCustomObject]@{ Name = $testVMName } }
                 Mock -CommandName Get-VMHardDiskDrive
 
                 $result = Get-TargetResource -VMName $testVMName -Path $testhardDiskPath
@@ -73,8 +76,28 @@ try
                 $result.Ensure | Should -Be 'Absent'
             }
 
+            It 'Should return "Absent" when VM does not exist' {
+                Mock -CommandName Get-VM
+                Mock -CommandName Get-VMHardDiskDrive
+
+                $result = Get-TargetResource -VMName $testVMName -Path $testhardDiskPath
+
+                $result.Ensure | Should -Be 'Absent'
+                $result.Path | Should -BeNullOrEmpty
+            }
+
+            It 'Should not call Get-VMHardDiskDrive when VM does not exist' {
+                Mock -CommandName Get-VM
+                Mock -CommandName Get-VMHardDiskDrive
+
+                $null = Get-TargetResource -VMName $testVMName -Path $testhardDiskPath
+
+                Assert-MockCalled -CommandName Get-VMHardDiskDrive -Times 0 -Scope It
+            }
+
             It 'Should assert Hyper-V module is installed' {
                 Mock -CommandName Assert-Module
+                Mock -CommandName Get-VM { return [PSCustomObject]@{ Name = $testVMName } }
                 Mock -CommandName Get-VMHardDiskDrive { return $stubHardDiskDrive }
 
                 $null = Get-TargetResource -VMName $testVMName -Path $testhardDiskPath


### PR DESCRIPTION
`Get-TargetResource` in `DSC_VMHardDiskDrive` throws when the specified VM does not exist because `Get-VMHardDiskDrive` is called with `-ErrorAction Stop`. This prevents `Test-TargetResource` from returning `$false` and aborts the entire `dsc config set` operation, even when `dependsOn` is correctly configured to create the VM first via `VMHyperV`.

This aligns with the [guidance from Microsoft](https://learn.microsoft.com/powershell/dsc/resources/authoringresourcemof) that `Get-TargetResource` must return a hashtable representing the current state of the resource, not throw an exception:

> The `Get-TargetResource` function [...] returns a hash table that contains the current values of all required properties.

This change checks for the VM with `Get-VM -ErrorAction SilentlyContinue` before querying hard disk drives. When the VM does not exist, returns `Ensure = 'Absent'` so DSC can correctly determine the resource is not in desired state and proceed with `Set-TargetResource` in dependency order.

#### This Pull Request (PR) fixes the following issues

- Fixes #223

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (where possible).
- [x] New/changed code adheres to DSC Community Style Guidelines.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/HyperVDsc/224)
<!-- Reviewable:end -->
