### PR TITLE
Vhd: Return bool instead of throwing when Path or ParentPath does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
     [guidance from Microsoft](https://learn.microsoft.com/powershell/dsc/resources/authoringresourcemof?view=dsc-1.1)
     that `Test-TargetResource` should return `$false` when the resource is
     not in the desired state, not throw an exception - Fixes
-    [Issue #225](https://github.com/dsccommunity/HyperVDsc/issues/225).
+    [issue #225](https://github.com/dsccommunity/HyperVDsc/issues/225).
 - HyperVDsc
   - BREAKING CHANGE
     - Renamed _xHyper-V_ to _HyperVDsc - fixes [Issue #69](https://github.com/dsccommunity/HyperVDsc/issues/213).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - Vhd
   - `Test-TargetResource` no longer throws when `Path` or `ParentPath` does
     not exist. Returns the correct boolean based on `Ensure` instead of
-    aborting the configuration - Fixes
+    aborting the configuration. This aligns with the
+    [guidance from Microsoft](https://learn.microsoft.com/powershell/dsc/resources/authoringresourcemof?view=dsc-1.1)
+    that `Test-TargetResource` should return `$false` when the resource is
+    not in the desired state, not throw an exception - Fixes
     [Issue #225](https://github.com/dsccommunity/HyperVDsc/issues/225).
 - HyperVDsc
   - BREAKING CHANGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+- Vhd
+  - `Test-TargetResource` no longer throws when `Path` or `ParentPath` does
+    not exist. Returns the correct boolean based on `Ensure` instead of
+    aborting the configuration - Fixes
+    [Issue #225](https://github.com/dsccommunity/HyperVDsc/issues/225).
 - HyperVDsc
   - BREAKING CHANGE
     - Renamed _xHyper-V_ to _HyperVDsc - fixes [Issue #69](https://github.com/dsccommunity/HyperVDsc/issues/213).

--- a/source/DSCResources/DSC_VHD/DSC_Vhd.psm1
+++ b/source/DSCResources/DSC_VHD/DSC_Vhd.psm1
@@ -311,7 +311,8 @@ function Test-TargetResource
     {
         if (!(Test-Path -Path $ParentPath))
         {
-            throw "$ParentPath does not exists"
+            Write-Verbose -Message "$ParentPath does not exist."
+            return ($Ensure -eq 'Absent')
         }
 
         # Check if the generation matches parenting disk
@@ -323,7 +324,8 @@ function Test-TargetResource
 
     if (!(Test-Path -Path $Path))
     {
-        throw "$Path does not exists"
+        Write-Verbose -Message "$Path does not exist."
+        return ($Ensure -eq 'Absent')
     }
 
     # Construct the full path for the vhdFile

--- a/source/DSCResources/DSC_VHD/DSC_Vhd.psm1
+++ b/source/DSCResources/DSC_VHD/DSC_Vhd.psm1
@@ -311,7 +311,7 @@ function Test-TargetResource
     {
         if (!(Test-Path -Path $ParentPath))
         {
-            Write-Verbose -Message "$ParentPath does not exist."
+            Write-Verbose -Message ($script:localizedData.PathDoesNotExist -f $ParentPath)
             return ($Ensure -eq 'Absent')
         }
 
@@ -324,7 +324,7 @@ function Test-TargetResource
 
     if (!(Test-Path -Path $Path))
     {
-        Write-Verbose -Message "$Path does not exist."
+        Write-Verbose -Message ($script:localizedData.PathDoesNotExist -f $Path)
         return ($Ensure -eq 'Absent')
     }
 

--- a/source/DSCResources/DSC_VHD/en-US/DSC_Vhd.strings.psd1
+++ b/source/DSCResources/DSC_VHD/en-US/DSC_Vhd.strings.psd1
@@ -1,2 +1,3 @@
 ConvertFrom-StringData @'
+    PathDoesNotExist = {0} does not exist.
 '@

--- a/tests/Unit/DSC_VHD.Tests.ps1
+++ b/tests/Unit/DSC_VHD.Tests.ps1
@@ -148,11 +148,27 @@ try
             }
 
             Context 'ParentPath specified' {
-                It 'Should throw when ParentPath does not exist' {
+                It 'Should return $false when ParentPath does not exist and Ensure is Present' {
+                    Mock -CommandName Test-Path -MockWith { $false }
+
+                    $result = Test-TargetResource -Name 'server' -Path 'C:\VMs' -Type 'Differencing' -ParentPath 'c:\boguspath' -Ensure 'Present'
+
+                    $result | Should -BeFalse
+                }
+
+                It 'Should return $true when ParentPath does not exist and Ensure is Absent' {
+                    Mock -CommandName Test-Path -MockWith { $false }
+
+                    $result = Test-TargetResource -Name 'server' -Path 'C:\VMs' -Type 'Differencing' -ParentPath 'c:\boguspath' -Ensure 'Absent'
+
+                    $result | Should -BeTrue
+                }
+
+                It 'Should not throw when ParentPath does not exist' {
                     Mock -CommandName Test-Path -MockWith { $false }
 
                     { Test-TargetResource -Name 'server' -Path 'C:\VMs' -Type 'Differencing' -ParentPath 'c:\boguspath' } |
-                        Should -Throw 'c:\boguspath does not exists'
+                        Should -Not -Throw
                 }
 
                 # "Generation $Generation should match ParentPath extension $($ParentPath.Split('.')[-1])"
@@ -165,11 +181,27 @@ try
             }
 
             Context 'Path does not exist' {
-                It 'Should throw when the path does not exist' {
+                It 'Should return $false when Ensure is Present' {
+                    Mock -CommandName Test-Path -MockWith { $false }
+
+                    $result = Test-TargetResource -Name 'server.vhdx' -Path 'C:\VMs' -Type 'Fixed' -MaximumSizeBytes 1GB -Ensure 'Present'
+
+                    $result | Should -BeFalse
+                }
+
+                It 'Should return $true when Ensure is Absent' {
+                    Mock -CommandName Test-Path -MockWith { $false }
+
+                    $result = Test-TargetResource -Name 'server.vhdx' -Path 'C:\VMs' -Type 'Fixed' -MaximumSizeBytes 1GB -Ensure 'Absent'
+
+                    $result | Should -BeTrue
+                }
+
+                It 'Should not throw' {
                     Mock -CommandName Test-Path -MockWith { $false }
 
                     { Test-TargetResource -Name 'server.vhdx' -Path 'C:\VMs' -Type 'Fixed' -MaximumSizeBytes 1GB } |
-                        Should -Throw 'C:\VMs does not exists'
+                        Should -Not -Throw
                 }
             }
 


### PR DESCRIPTION
`Test-TargetResource` in `DSC_Vhd` throws when the `Path` or `ParentPath` directory does not exist. This aligns with the [guidance from Microsoft](https://learn.microsoft.com/powershell/dsc/resources/authoringresourcemof?view=dsc-1.1) that `Test-TargetResource` should return a boolean, not throw an exception:

> In your implementation of `Test-TargetResource`, check the status of the resource instance that is specified in the key parameters. If the actual status of the resource instance does not match the values specified in the parameter set, return `$false`. Otherwise, return `$true`.

This change replaces the throws with `return ($Ensure -eq 'Absent')`:
- If `Ensure` is `Present` and the path is missing → returns `$false` (not in desired state)
- If `Ensure` is `Absent` and the path is missing → returns `$true` (VHD can't exist, desired state met)

Unit tests updated to verify the new behavior for both `Present` and `Absent` scenarios on both `Path` and `ParentPath`.

#### This Pull Request (PR) fixes the following issues

- Fixes #225

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md. Entry should say what was changed and how that affects users (if applicable), and reference the issue being resolved (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines (https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/HyperVDsc/226)
<!-- Reviewable:end -->
